### PR TITLE
Remove pkg-config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN         apt-get update \
                 git-buildpackage \
                 libtool \
                 nano \
-                pkg-config \
                 quilt \
                 reportbug \
                 sudo \


### PR DESCRIPTION
pkg-config should not be part of a debian maintainer clean environment